### PR TITLE
Always log uncaught exceptions as level ERROR

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -668,12 +668,12 @@ class Chalice(object):
                                 status_code=e.STATUS_CODE)
         except Exception as e:
             headers = {}
+            self.log.error("Caught exception for %s", view_function,
+                           exc_info=True)
             if self.debug:
                 # If the user has turned on debug mode,
-                # we'll let the original exception propogate so
+                # we'll let the original exception propagate so
                 # they get more information about what went wrong.
-                self.log.debug("Caught exception for %s", view_function,
-                               exc_info=True)
                 stack_trace = ''.join(traceback.format_exc())
                 body = stack_trace
                 headers['Content-Type'] = 'text/plain'


### PR DESCRIPTION
Proposed change for #969.